### PR TITLE
Implement some filename cleanup logic #hacktoberfest

### DIFF
--- a/backend/src/main/java/de/grimsi/gameyfin/service/LibraryService.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/service/LibraryService.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static de.grimsi.gameyfin.util.FilenameUtil.getFilenameWithoutExtension;
+import static de.grimsi.gameyfin.util.FilenameUtil.getFilenameWithoutAdditions;
 import static de.grimsi.gameyfin.util.FilenameUtil.hasGameArchiveExtension;
 
 @Slf4j
@@ -91,7 +91,7 @@ public class LibraryService {
         // If a game is not found on IGDB, blacklist the path, so we won't query the API later for the same path
         List<DetectedGame> newDetectedGames = gameFiles.parallelStream()
                 .map(p -> {
-                    Optional<Igdb.Game> optionalGame = igdbWrapper.searchForGameByTitle(getFilenameWithoutExtension(p));
+                    Optional<Igdb.Game> optionalGame = igdbWrapper.searchForGameByTitle(getFilenameWithoutAdditions(p));
 
                     if(optionalGame.isPresent() && detectedGameRepository.existsBySlug(optionalGame.get().getSlug())) {
                         log.warn("Game with slug '{}' already exists in database", optionalGame.get().getSlug());

--- a/backend/src/main/java/de/grimsi/gameyfin/util/FilenameUtil.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/util/FilenameUtil.java
@@ -7,15 +7,29 @@ import org.springframework.stereotype.Service;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 public class FilenameUtil {
 
     private static List<String> possibleGameFileExtensions;
+    private static List<String> possibleGameFileSuffixes;
+    // matches v1.1.1 v1.1 v1 version numbers
+    private static Pattern versionPattern = Pattern.compile("v(\\d+\\.)?(\\d+\\.)?(\\d+)");
+    private static Pattern trailingNoisePattern = Pattern.compile("( |\\(\\)|[-_.])+$");
+    private static Pattern headingNoisePattern = Pattern.compile("^( |\\(\\)|[-_.])+");
 
     @Value("${gameyfin.file-extensions}")
     public void setPossibleGameFileExtensions(List<String> possibleGameFileExtensions) {
         FilenameUtil.possibleGameFileExtensions = possibleGameFileExtensions;
+    }
+    
+    @Value("${gameyfin.file-suffixes}")
+    public void setPossibleGameFileSuffixes(List<String> possibleGameFileSuffixes) {
+        FilenameUtil.possibleGameFileSuffixes = possibleGameFileSuffixes;
+        // Sort in decending length, so for example "windows" gets checked before "win"
+        FilenameUtil.possibleGameFileSuffixes.sort((s1,s2) -> Integer.compare(s2.length(), s1.length()));
     }
 
     public static String getFilenameWithoutExtension(Path p) {
@@ -33,6 +47,27 @@ public class FilenameUtil {
 
     public static boolean hasGameArchiveExtension(Path p) {
         return possibleGameFileExtensions.contains(FilenameUtils.getExtension(p.getFileName().toString()));
+    }
+    
+    public static String getFilenameWithoutAdditions(Path p) {
+        String name = getFilenameWithoutExtension(p).toLowerCase();
+        for(String suffix : possibleGameFileSuffixes) {
+            name = name.replace(suffix, "");
+        }
+        name = removePattern(name, versionPattern);
+        name = removePattern(name, trailingNoisePattern);
+        name = removePattern(name, headingNoisePattern);
+        
+        // sanity check to never return an empty name
+        return name.isBlank() ? getFilenameWithoutExtension(p) : name;
+    }
+    
+    public static String removePattern(String string, Pattern pattern) {
+        Matcher matcher = pattern.matcher(string);
+        if(matcher.find()) {
+            return matcher.replaceAll("");
+        }
+        return string;
     }
 
 }

--- a/backend/src/main/resources/config/gameyfin.yml
+++ b/backend/src/main/resources/config/gameyfin.yml
@@ -2,6 +2,7 @@ gameyfin:
   db: ""
   cache: ""
   file-extensions: iso, zip, rar, 7z, exe
+  file-suffixes: windows, win, english, win32, win64, opengl, stable
   igdb:
     api:
       client-id:


### PR DESCRIPTION
Removes some common file suffixes from files downloaded from for example itch.io. Also removes trailing/leading whitespace/-/_/./()  and version numbers starting with a "v" like "v1.2.3".

Tested with these files directly downloaded from itch.io:
```
celeste-win-opengl.zip
crosscode-new-win32.zip
Evergate-v1.05.4.zip
gnog-win.zip
lennas-inception-windows-stable.zip
super_hexagon-windows.zip
```
Currently, it's unable to match a single zip file to a game. This change enables it to match most files correctly on it's own.
It failed on: 
``lennas-inception-windows-stable.zip`` which got resolved to ``lennas-inception``, which does match the IGDB slug. Maybe the matching failed due to the missing ' ?
``crosscode-new-win32.zip`` was parsed as ``crosscode-new``, not sure what the "new" part in the name is since that's not part of the title.