### PR TITLE
feat(download): add file size calculation for DownloadService

### DIFF
--- a/backend/src/main/java/de/grimsi/gameyfin/rest/GamesController.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/rest/GamesController.java
@@ -5,11 +5,16 @@ import de.grimsi.gameyfin.entities.DetectedGame;
 import de.grimsi.gameyfin.service.DownloadService;
 import de.grimsi.gameyfin.service.GameService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -50,10 +55,21 @@ public class GamesController {
         DetectedGame game = gameService.getDetectedGame(slug);
 
         String downloadFileName = downloadService.getDownloadFileName(game);
+        long downloadFileSize = downloadService.getDownloadFileSize(game);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"%s\"".formatted(downloadFileName));
+        headers.add(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate");
+        headers.add(HttpHeaders.PRAGMA, "no-cache");
+        headers.add(HttpHeaders.EXPIRES, "0");
+        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        if (downloadFileSize > 0) {
+            headers.setContentLength(downloadFileSize);
+        }
 
         return ResponseEntity
                 .ok()
-                .header("Content-Disposition", "attachment; filename=\"%s\"".formatted(downloadFileName))
+                .headers(headers)
                 .body(out -> downloadService.sendGamefilesToClient(game, out));
     }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.2.3-SNAPSHOT",
+  "version": "1.2.4-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.2.3-SNAPSHOT",
+      "version": "1.2.4-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^14.0.0",
         "@angular/cdk": "^14.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.2.3-SNAPSHOT",
+  "version": "1.2.4-SNAPSHOT",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
This allows the browser to show file size and a time estimate for downloading files. 
Does not work for ZipOutputStreams though since dir size doesn't match the zip file size. 
Also added no-cache headers so browser won't start caching downloads.