### PR TITLE
feat(refresh): added refresh button on game detail view to refresh metadata

### DIFF
--- a/backend/src/main/java/de/grimsi/gameyfin/rest/GamesController.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/rest/GamesController.java
@@ -44,7 +44,7 @@ public class GamesController {
         return gameService.getAllMappings();
     }
 
-    @GetMapping(value="/game/{slug}/download")
+    @GetMapping(value = "/game/{slug}/download")
     public ResponseEntity<StreamingResponseBody> downloadGameFiles(@PathVariable String slug) {
 
         DetectedGame game = gameService.getDetectedGame(slug);
@@ -55,6 +55,11 @@ public class GamesController {
                 .ok()
                 .header("Content-Disposition", "attachment; filename=\"%s\"".formatted(downloadFileName))
                 .body(out -> downloadService.sendGamefilesToClient(game, out));
+    }
+
+    @GetMapping(value = "/game/{slug}/refresh", produces = MediaType.APPLICATION_JSON_VALUE)
+    public DetectedGame refreshGame(@PathVariable String slug) {
+        return gameService.refreshGame(slug);
     }
 
 }

--- a/frontend/src/app/api/GamesApi.ts
+++ b/frontend/src/app/api/GamesApi.ts
@@ -7,4 +7,5 @@ export interface GamesApi {
   getGame(slug: String): Observable<DetectedGameDto>;
   getGameOverviews(): Observable<GameOverviewDto[]>;
   getAllGameMappings(): Observable<Map<string, string>>;
+  refreshGame(slug: String): Observable<DetectedGameDto>;
 }

--- a/frontend/src/app/components/game-detail-view/game-detail-view.component.html
+++ b/frontend/src/app/components/game-detail-view/game-detail-view.component.html
@@ -33,6 +33,9 @@
       <div fxLayout="column" fxFlex="40" fxLayoutGap="16px">
 
         <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="16px">
+          <button mat-raised-button color="secondary" (click)="refreshGame()" title="Refresh metadata">
+            <mat-icon>refresh</mat-icon>
+          </button>
           <button mat-raised-button color="primary" (click)="downloadGame()">
             <mat-icon>download</mat-icon>
           </button>

--- a/frontend/src/app/components/game-detail-view/game-detail-view.component.ts
+++ b/frontend/src/app/components/game-detail-view/game-detail-view.component.ts
@@ -48,6 +48,24 @@ export class GameDetailViewComponent {
     this.gamesService.downloadGame(this.game.slug);
   }
 
+  public refreshGame(): void {
+    this.gamesService.refreshGame(this.game.slug).subscribe({
+      next: game => {
+        this.game = game;
+        if(game.companies !== undefined) {
+          this.companiesWithLogo = game.companies.filter(c => c.logoId !== undefined && c.logoId.length > 0);
+        }
+      },
+      error: error => {
+        if (error.status === 404) {
+          this.router.navigate(['/library']);
+        } else {
+          console.error(error);
+        }
+      }
+   });
+  }
+
   public bytesAsHumanReadableString(bytes: number): string {
     const thresh = 1024;
 

--- a/frontend/src/app/services/games.service.ts
+++ b/frontend/src/app/services/games.service.ts
@@ -92,6 +92,10 @@ export class GamesService implements GamesApi {
     window.open(`v1${this.apiPath}/game/${slug}/download`, '_top');
   }
 
+  refreshGame(slug: String): Observable<DetectedGameDto> {
+    return this.http.get<DetectedGameDto>(`${this.apiPath}/game/${slug}/refresh`);
+  }
+
   getGameOverviews(): Observable<GameOverviewDto[]> {
     return this.http.get<GameOverviewDto[]>(`${this.apiPath}/game-overviews`);
   }


### PR DESCRIPTION
This adds a refresh button to refresh metadata of a game.
This is useful for when new features for GameyFin add more metadata or when metadata was incomplete but has been adapted.

Now games don't have to be removed and re-added if metadata changes.

Resolves grimsi/gameyfin#45