### PR TITLE
fix(game-detail): prevent overflow of long company logos

### DIFF
--- a/frontend/src/app/components/game-detail-view/game-detail-view.component.html
+++ b/frontend/src/app/components/game-detail-view/game-detail-view.component.html
@@ -3,7 +3,7 @@
   <div fxLayout="column" fxFlex="0 1 75" fxLayoutGap="16px" fxFlex.lt-lg="95">
     <div fxLayout="row" fxLayout.lt-lg="column" fxLayoutGap="16px">
 
-      <mat-card fxFlex="60" fxLayout="row" fxLayout.lt-lg="column" fxLayoutGap="16px">
+      <mat-card fxFlex="100" fxLayout="row" fxLayout.lt-lg="column" fxLayoutGap="16px">
         <div fxLayoutAlign="start" fxLayoutAlign.lt-lg="center">
           <img src="v1/images/{{game.coverId}}" style="max-height: 352px" alt="Game cover">
         </div>
@@ -20,8 +20,8 @@
           <div *ngIf="companiesWithLogo.length > 0">
             <h2>Developed by</h2>
             <div fxLayout="row wrap" fxLayoutGap="8px grid">
-              <div *ngFor="let company of companiesWithLogo">
-                <img style="height: 52px;" src="v1/images/{{company.logoId}}" alt="{{company.name}}" [matTooltip]="company.name">
+              <div *ngFor="let company of companiesWithLogo" class="company-logos">
+                <img src="v1/images/{{company.logoId}}" alt="{{company.name}}" [matTooltip]="company.name">
               </div>
             </div>
           </div>

--- a/frontend/src/app/components/game-detail-view/game-detail-view.component.scss
+++ b/frontend/src/app/components/game-detail-view/game-detail-view.component.scss
@@ -1,0 +1,8 @@
+.mat-card {
+//   min-height: max-content;
+
+  .company-logos img {
+    max-height: 52px;
+    max-width: 260px;
+  }
+}


### PR DESCRIPTION
This should fix grimsi/gameyfin#55 on a horizontal and on the vertical level since this bug also appeared on mobile screens on the vertical.

