### PR TITLE
Torrent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ Since Gameyfin loads information from IGDB, you need to register yourself there.
 3. Edit the config options in the `gameyfin.properties` file
 4. Use the following command to start Gameyfin: `java -jar gameyfin.jar`
 5. Open the address of your Gameyfin host in your browser, Gameyfin runs under port 8080 by default
+
+
+### Torrents
+
+Gameyfin also has an integrated torrent tracker running to easily share games with your friends. It runs per default on port 6969.
+To share games, press the "Torrent" button on the detail-page of the game you want to share and add the downloaded .torrent file to your client.
+Gameyfin then seeds the game until one client has successfully downloaded the whole game. After this, you can share the .torrent file with your friends and share the game via bittorrent.
+
+For security reasons, Gameyfin only accepts torrents it itself has created, but this data will be saved on the disk, so the .torrent files can be re-used even after a restart
+
+To use the bittorrent client, either set `gameyfin.torrent` in `gameyfin.properties` or the environment variable `GAMEYFIN_TORRENT` to a path where the torrent files should be stored

--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ Gameyfin then seeds the game until one client has successfully downloaded the wh
 For security reasons, Gameyfin only accepts torrents it itself has created, but this data will be saved on the disk, so the .torrent files can be re-used even after a restart
 
 To use the bittorrent client, either set `gameyfin.torrent` in `gameyfin.properties` or the environment variable `GAMEYFIN_TORRENT` to a path where the torrent files should be stored
+Also, if you want to use the torrent tracker externally or have set an unresolvable hostname on your machine, use `gameyfin.torrenthostname` or `GAMEYFIN_TORRENTHOSTNAME` to set a valid hostname which will be used for the announce URL of the torrents

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -12,6 +12,13 @@
 
     <packaging>jar</packaging>
 
+    <repositories>
+		<repository>
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+		</repository>
+	</repositories>
+
     <properties>
         <java.version>18</java.version>
 
@@ -167,6 +174,11 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+	    <groupId>com.github.mpetazzoni</groupId>
+	    <artifactId>ttorrent</artifactId>
+	    <version>ttorrent-2.0</version>
+	</dependency>
     </dependencies>
 
     <build>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -13,11 +13,16 @@
     <packaging>jar</packaging>
 
     <repositories>
-		<repository>
-		    <id>jitpack.io</id>
-		    <url>https://jitpack.io</url>
-		</repository>
-	</repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+        <repository>
+            <id>central</id>
+            <name>Maven Repository Switchboard</name>
+            <url>http://repo1.maven.org/maven2</url>
+        </repository>
+    </repositories>
 
     <properties>
         <java.version>18</java.version>
@@ -175,10 +180,15 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-	    <groupId>com.github.mpetazzoni</groupId>
-	    <artifactId>ttorrent</artifactId>
-	    <version>ttorrent-2.0</version>
-	</dependency>
+            <groupId>com.github.mpetazzoni</groupId>
+            <artifactId>ttorrent</artifactId>
+            <version>ttorrent-2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.atomashpolskiy</groupId>
+            <artifactId>bt-core</artifactId>
+            <version>1.10</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/de/grimsi/gameyfin/GameyfinApplication.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/GameyfinApplication.java
@@ -1,7 +1,10 @@
 package de.grimsi.gameyfin;
 
+import com.turn.ttorrent.tracker.Tracker;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+
+import java.io.IOException;
 
 @SpringBootApplication
 public class GameyfinApplication {

--- a/backend/src/main/java/de/grimsi/gameyfin/config/FilesystemConfig.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/config/FilesystemConfig.java
@@ -37,6 +37,9 @@ public class FilesystemConfig {
     @Value("${gameyfin.cache}")
     private String cachePath;
 
+    @Value("${gameyfin.torrent}")
+    private String torrentPath;
+
     @Autowired
     Environment env;
 

--- a/backend/src/main/java/de/grimsi/gameyfin/rest/GamesController.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/rest/GamesController.java
@@ -1,10 +1,15 @@
 package de.grimsi.gameyfin.rest;
 
+import bt.torrent.maker.TorrentBuilder;
+import com.turn.ttorrent.common.creation.MetadataBuilder;
 import de.grimsi.gameyfin.dto.GameOverviewDto;
 import de.grimsi.gameyfin.entities.DetectedGame;
 import de.grimsi.gameyfin.service.DownloadService;
 import de.grimsi.gameyfin.service.GameService;
+import de.grimsi.gameyfin.service.TorrentService;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -12,11 +17,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * This controller handles logic related to detected games.
@@ -28,6 +37,18 @@ public class GamesController {
 
     private final GameService gameService;
     private final DownloadService downloadService;
+
+    @Value("${gameyfin.torrent}")
+    private String torrentFolderPath;
+
+    @Value("${gameyfin.trackerhostname}")
+    private String trackerHostname;
+
+    @Value("${gameyfin.trackerport}")
+    private String trackerPort;
+
+    @Value("${gameyfin.trackerssl}")
+    private boolean trackerSSL;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public List<DetectedGame> getAllGames() {
@@ -71,6 +92,76 @@ public class GamesController {
                 .ok()
                 .headers(headers)
                 .body(out -> downloadService.sendGamefilesToClient(game, out));
+    }
+
+    @GetMapping(value = "/game/{slug}/torrent")
+    public ResponseEntity<StreamingResponseBody> downloadGameTorrent(@PathVariable String slug) {
+        if (!TorrentService.isTrackerEnabled()) {
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate");
+            headers.add(HttpHeaders.PRAGMA, "no-cache");
+            headers.add(HttpHeaders.EXPIRES, "0");
+            return (ResponseEntity<StreamingResponseBody>) ResponseEntity
+                    //TODO what to return here??
+                    .status(501)
+                    .headers(headers);
+        }
+
+        DetectedGame game = gameService.getDetectedGame(slug);
+
+        String downloadFileName = downloadService.getTorrentFileName(game);
+
+        Path torrentPath = Path.of(torrentFolderPath + "/" + downloadFileName);
+
+        try {
+            Path torrentRoot = Paths.get(game.getPath());
+            TorrentBuilder torrentBuilder = new TorrentBuilder()
+                    .rootPath(torrentRoot);
+
+            List<Path> gameContent = Files.walk(Path.of(game.getPath())).collect(Collectors.toList());
+
+            for (Path p : gameContent) {
+                torrentBuilder.addFile(p);
+            }
+
+            String announceURL = "";
+            if (trackerHostname.equals("localhost")) {
+                announceURL = TorrentService.getAnnounceURL();
+            } else {
+                announceURL = (trackerSSL ? "https://" : "http://") + trackerHostname + ":" + trackerPort + "/announce";
+            }
+
+            System.out.println(announceURL);
+
+            byte[] torrentMetadataBytes = torrentBuilder
+                    .announce((announceURL))
+                    .build();
+            FileUtils.writeByteArrayToFile(torrentPath.toFile(), torrentMetadataBytes);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        long downloadFileSize = 0;
+        try {
+            downloadFileSize = Files.size(torrentPath);
+        } catch (IOException e) {
+
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"%s\"".formatted(downloadFileName));
+        headers.add(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate");
+        headers.add(HttpHeaders.PRAGMA, "no-cache");
+        headers.add(HttpHeaders.EXPIRES, "0");
+        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        if (downloadFileSize > 0) {
+            headers.setContentLength(downloadFileSize);
+        }
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(out -> downloadService.sendTorrentToClient(game, torrentPath, out));
     }
 
     @GetMapping(value = "/game/{slug}/refresh", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/main/java/de/grimsi/gameyfin/service/DownloadService.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/service/DownloadService.java
@@ -114,11 +114,15 @@ public class DownloadService {
         log.info("Downloaded torrentfile of {} in {} seconds.", game.getTitle(), (int) stopWatch.getTotalTimeSeconds());
 
 
-        //Starting new thread to seed torrent to one client
+        //Adding torrent to tracker and starting to seed it
         TorrentService.announceTorrent(torrentFile.toFile());
-        Runnable seedRunnable = new TorrentSeedService(torrentFile, game.getPath());
-        Thread seedThread = new Thread(seedRunnable);
-        seedThread.start();
+        try {
+            TorrentService.getSeedService().addTorrentToSeed(torrentFile, game.getPath());
+        } catch (Exception e){
+            log.error("Failed to seed torrent: {}", e.toString());
+            return;
+        }
+        log.info("Successfully added torrent to tracker and starting to seed");
     }
 
     private void sendGamefileToClient(Path path, OutputStream outputStream) {

--- a/backend/src/main/java/de/grimsi/gameyfin/service/TorrentSeedService.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/service/TorrentSeedService.java
@@ -1,0 +1,58 @@
+package de.grimsi.gameyfin.service;
+
+import com.turn.ttorrent.client.CommunicationManager;
+import com.turn.ttorrent.client.SharedTorrent;
+import com.turn.ttorrent.client.SimpleClient;
+import com.turn.ttorrent.client.peer.SharingPeer;
+import com.turn.ttorrent.client.storage.FullyPieceStorageFactory;
+import org.checkerframework.checker.units.qual.C;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class TorrentSeedService implements Runnable {
+
+    private Path torrentPath;
+    private String gamePath;
+
+    public TorrentSeedService(Path torrentPath, String gamePath) {
+        this.torrentPath = torrentPath;
+        this.gamePath = gamePath;
+    }
+
+    public void run() {
+        InetAddress seedAddress = new InetSocketAddress(0).getAddress();
+
+        ExecutorService workingExecutor = Executors.newFixedThreadPool(8);
+        ExecutorService validatorExecutor = Executors.newFixedThreadPool(8);
+        CommunicationManager cm = new CommunicationManager(workingExecutor, validatorExecutor);
+        try {
+            cm.start(seedAddress);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            cm.addTorrent(torrentPath.toString(), gamePath, FullyPieceStorageFactory.INSTANCE);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        while (true) {
+            for (SharedTorrent torrent : cm.getTorrents()) {
+                for (SharingPeer peer : cm.getPeersForTorrent(torrent.getHexInfoHash())) {
+                    System.out.println(peer.getIp());
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+}

--- a/backend/src/main/java/de/grimsi/gameyfin/service/TorrentService.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/service/TorrentService.java
@@ -22,6 +22,12 @@ public class TorrentService implements ApplicationListener<ApplicationReadyEvent
 
     private static Tracker tracker;
 
+    public static TorrentSeedService getSeedService() {
+        return seedService;
+    }
+
+    private static TorrentSeedService seedService;
+
     @Value("${gameyfin.torrent}")
     private String torrentFolderPath;
 
@@ -91,5 +97,14 @@ public class TorrentService implements ApplicationListener<ApplicationReadyEvent
         } catch (IOException e) {
             log.error("Failed to start internal torrent tracker");
         }
+        log.info("Starting internal torrent seedservice");
+        try {
+            seedService = new TorrentSeedService();
+            log.info("Successfully started seedservice");
+        } catch (Exception e){
+            log.info("Failed to start seedservice: {}", e.toString());
+            log.info("Torrents will not be seeded this session");
+        }
+
     }
 }

--- a/backend/src/main/java/de/grimsi/gameyfin/service/TorrentService.java
+++ b/backend/src/main/java/de/grimsi/gameyfin/service/TorrentService.java
@@ -1,0 +1,61 @@
+package de.grimsi.gameyfin.service;
+
+import com.turn.ttorrent.tracker.TrackedTorrent;
+import com.turn.ttorrent.tracker.Tracker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Slf4j
+@Component
+@Service
+public class TorrentService implements ApplicationListener<ApplicationReadyEvent> {
+
+    private static Tracker tracker;
+
+    @Value("${gameyfin.torrent}")
+    private String torrentFolderPath;
+
+    @Value("${gameyfin.trackerport}")
+    private int trackerPort;
+
+    public void createTorrentFolder() throws IOException {
+        Files.createDirectories(Path.of(torrentFolderPath));
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        if(torrentFolderPath.equals("")){
+            log.info("No torrent path set, not starting with torrent support");
+            return;
+        }
+        log.info("Loading created torrents from {}", torrentFolderPath);
+        try {
+            tracker = new Tracker(trackerPort);
+            //Load every .torrent file contained in the folder
+            FilenameFilter filter = new FilenameFilter() {
+                @Override
+                public boolean accept(File dir, String name) {
+                    return name.endsWith(".torrent");
+                }
+            };
+            for (File f : new File(torrentFolderPath).listFiles(filter)) {
+                log.info("Loaded torrentfile {}", f.toString());
+                tracker.announce(TrackedTorrent.load(f));
+            }
+            //Finally start the tracker
+            tracker.start(true);
+        } catch (IOException e) {
+            log.error("Failed to start internal torrent tracker");
+        }
+    }
+}

--- a/backend/src/main/resources/config/gameyfin.yml
+++ b/backend/src/main/resources/config/gameyfin.yml
@@ -2,7 +2,9 @@ gameyfin:
   db: ""
   cache: ""
   torrent: ""
+  trackerhostname: localhost
   trackerport: 6969
+  trackerssl: false
   file-extensions: iso, zip, rar, 7z, exe
   igdb:
     api:

--- a/backend/src/main/resources/config/gameyfin.yml
+++ b/backend/src/main/resources/config/gameyfin.yml
@@ -1,6 +1,8 @@
 gameyfin:
   db: ""
   cache: ""
+  torrent: ""
+  trackerport: 6969
   file-extensions: iso, zip, rar, 7z, exe
   igdb:
     api:

--- a/config/gameyfin.properties
+++ b/config/gameyfin.properties
@@ -1,5 +1,8 @@
-# Uncomment if you want to change the port from 8080
+# Uncomment if you want to change the webserver port from 8080
 # server.port=8081
+
+# Uncomment if you want to change the tracker port from 6969
+# gameyfin.trackerport=42069
 
 # Gameyfin admin interface username and password
 gameyfin.user=<your username here>
@@ -13,6 +16,9 @@ gameyfin.sources=<comma-seperated list of root folders of your game libraries>
 
 # Uncomment if you want to specify the Gameyfin cache path (default is <game library root>/.gameyfin/cache)
 # gameyfin.cache=<custom path to cache folder>
+
+# Uncomment if you want to specify the Gameyfin torrent save path (default is <game library root>/.gameyfin/torrent)
+# gameyfin.torrent=<custom path to torrent folder>
 
 # Your twitch client-id and client-secret
 gameyfin.igdb.api.client-id=<your twitch client-id here>

--- a/config/gameyfin.properties
+++ b/config/gameyfin.properties
@@ -1,8 +1,15 @@
 # Uncomment if you want to change the webserver port from 8080
 # server.port=8081
 
+# Set this to the hostname other people can access gameyfin with.
+# The created torrents will use this hostname as the tracker url. If this is not set, the hostname of the machine gameyfin is running on will be used.
+# gameyfin.trackerhostname=gameyfin.local
+
 # Uncomment if you want to change the tracker port from 6969
 # gameyfin.trackerport=42069
+
+# Uncomment if you use a reverse proxy with SSL termination for the tracker
+# gameyfin.trackerssl=true
 
 # Gameyfin admin interface username and password
 gameyfin.user=<your username here>

--- a/docker/docker-compose.example-with-multiple-source-folders.yml
+++ b/docker/docker-compose.example-with-multiple-source-folders.yml
@@ -9,10 +9,12 @@ services:
       - GAMEYFIN_IGDB_API_CLIENT_ID=<your twitch client-id here>
       - GAMEYFIN_IGDB_API_CLIENT_SECRET=<your twitch client-secret here>
       - GAMEYFIN_SOURCES=/opt/gameyfin-library/library-1,/opt/gameyfin-library/library-2,/opt/gameyfin-library/library-3
+#      - GAMEYFIN_TORRENT=opt/gameyfin-torrents   #uncomment if you want to use torrents
     volumes:
       - <Path on your host to the 1st source folder>:/opt/gameyfin-library/library-1
       - <Path on your host to the 2nd source folder>:/opt/gameyfin-library/library-2
       - <Path on your host to the 3rd source folder>:/opt/gameyfin-library/library-3
+    #      - <path to your torrentcache>:/opt/gameyfin-torrents
     ports:
       - "8080:8080"
       - "6969:6969"

--- a/docker/docker-compose.example-with-multiple-source-folders.yml
+++ b/docker/docker-compose.example-with-multiple-source-folders.yml
@@ -15,3 +15,4 @@ services:
       - <Path on your host to the 3rd source folder>:/opt/gameyfin-library/library-3
     ports:
       - "8080:8080"
+      - "6969:6969"

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -8,8 +8,10 @@ services:
       - GAMEYFIN_PASSWORD=<your password here>
       - GAMEYFIN_IGDB_API_CLIENT_ID=<your twitch client-id here>
       - GAMEYFIN_IGDB_API_CLIENT_SECRET=<your twitch client-secret here>
+#      - GAMEYFIN_TORRENT=opt/gameyfin-torrents   #uncomment if you want to use torrents
     volumes:
       - <path to your game library>:/opt/gameyfin-library
+#      - <path to your torrentcache>:/opt/gameyfin-torrents
     ports:
       - "8080:8080"
       - "6969:6969"

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -12,3 +12,4 @@ services:
       - <path to your game library>:/opt/gameyfin-library
     ports:
       - "8080:8080"
+      - "6969:6969"

--- a/frontend/src/app/components/game-detail-view/game-detail-view.component.html
+++ b/frontend/src/app/components/game-detail-view/game-detail-view.component.html
@@ -39,7 +39,12 @@
           <button mat-raised-button color="primary" (click)="downloadGame()">
             <mat-icon>download</mat-icon>
           </button>
-          <b style="font-size: 24px">Download ({{bytesAsHumanReadableString(game.diskSize)}})</b>
+          <b style="font-size: 24px">Direct download({{bytesAsHumanReadableString(game.diskSize)}})</b>
+          <br>
+          <button mat-raised-button color="primary" (click)="downloadTorrent()">
+            <mat-icon>arrow_circle_up</mat-icon>
+          </button>
+          <b style="font-size: 24px">Torrent download</b>
         </div>
 
         <div fxLayout="column" fxLayoutGap="24px">

--- a/frontend/src/app/components/game-detail-view/game-detail-view.component.ts
+++ b/frontend/src/app/components/game-detail-view/game-detail-view.component.ts
@@ -50,6 +50,11 @@ export class GameDetailViewComponent {
     this.gamesService.downloadGame(this.game.slug);
   }
 
+  public downloadTorrent(): void {
+    this.gamesService.downloadTorrent(this.game.slug);
+  }
+
+
   public refreshGame(): void {
     this.gamesService.refreshGame(this.game.slug).subscribe({
       next: game => {

--- a/frontend/src/app/services/games.service.ts
+++ b/frontend/src/app/services/games.service.ts
@@ -107,6 +107,10 @@ export class GamesService implements GamesApi {
     window.open(`v1${this.apiPath}/game/${slug}/download`, '_top');
   }
 
+  downloadTorrent(slug: String): void {
+    window.open(`v1${this.apiPath}/game/${slug}/torrent`, '_top');
+  }
+
   refreshGame(slug: String): Observable<DetectedGameDto> {
     return this.http.get<DetectedGameDto>(`${this.apiPath}/game/${slug}/refresh`);
   }


### PR DESCRIPTION
## Dont merge for now, question pending

This pull requests adds support for torrents.
For this, an internal torrent tracker is added, which is listening on port 6969 if enabled.
To enable the tracker, a torrent directory has to be set via the config or env variables.
For security reasons, the tracker only announces torrents gameyfin itself has created, which is why the torrent directory has to be set. Every created torrent will be loaded into this directory and, in case of a restart, be reregistered to the tracker.
It is also possible to change the hostname, port and protocol(http/https) the tracker is listening on.

When a user presses on "Torrent download", the .torrent file is created and served to the user.
Additionally, the .torrent is added to the seedservice, where it is being served to the user.

### Question
Currently, the torrent is seeding indefinitly, but there are three possiblities.
1. Stop the seeding after a set amount of time (24h default, but can be adjusted)
2. Seed forever (until the server is restarted, this sounds expensive but should use not many resources at all)
3. Seed only until one client has been served 100%

For all possibilities, its possible to restart the seed process by clicking to "Download torrent" button again.
As for the implementation, method 2 is currenty implemented as it was the easiest.
Method 1 would also be pretty easy and consistent, and also probably sufficient and use less resources.
Method 3 would technically be the cleanest, but is not possible, as its not possible to see the seed ratio of the Java client (it may be with some trickery, but that would be unreliable if two clients are leeching at the same time).
It is possible though to check the amount of seeders of the torrent.

My proposal would be to:
1. Start seeding (Torrent has 1 seeder)
2. Check with an interval how many seeder the torrent hast
3. Client has 100%ed the torrent (Now there are two seeders)
4. Service checks that there are two seeders and stops seeding, as one client is fully served.
This would be the best method IMO, but has the downside that, if one user is still seeding the same torrent from earlier, gameyfin will not seed the torrent again if a user requests it and only the first downloader will continue to seed.
This MAY lead to less speed, but I dont think this is a problem.



BTW, I hope the documentation in the readme is sufficient, if not, please tell me what is unclear and Ill append it.


![image](https://user-images.githubusercontent.com/11798845/198557612-e6bcf3b7-6a9c-498d-a26a-92b346fa0e05.png)


Closing https://github.com/grimsi/gameyfin/issues/24