### PR TITLE
Export default port in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,4 +13,6 @@ COPY ${JAR_FILE} /opt/gameyfin/gameyfin.jar
 
 WORKDIR /opt/gameyfin
 
+EXPOSE 8080
+
 ENTRYPOINT ["java", "-jar", "gameyfin.jar"]


### PR DESCRIPTION
- Thanks to this, the necessary port can be auto-detected by reverse-proxies, e.g. Traefik