### PR TITLE
Add missing Content-Type header to downloads

### DIFF
--- a/app/src/main/kotlin/org/gameyfin/app/core/download/files/DownloadEndpoint.kt
+++ b/app/src/main/kotlin/org/gameyfin/app/core/download/files/DownloadEndpoint.kt
@@ -44,11 +44,26 @@ class DownloadEndpoint(
 
                 val result = when (val download = downloadService.getDownload(game.metadata.path, provider)) {
                     is FileDownload -> {
+                        val filename = if (download.fileExtension != null) {
+                            "${game.title}.${download.fileExtension}"
+                        } else {
+                            game.title
+                        }
+
                         val responseBuilder = ResponseEntity.ok()
                             .header(
                                 "Content-Disposition",
-                                "attachment; filename=\"${game.title}.${download.fileExtension}\""
+                                "attachment; filename=\"$filename\""
                             )
+                            .header(
+                                "Content-Type",
+                                "application/octet-stream"
+                            )
+
+                        val downloadSize = download.size
+                        if(downloadSize != null) {
+                            responseBuilder.contentLength(downloadSize)
+                        }
 
                         responseBuilder.body(StreamingResponseBody { outputStream ->
                             downloadService.processDownload(

--- a/plugins/directdownload/src/main/kotlin/org/gameyfin/plugins/download/direct/DirectDownloadPlugin.kt
+++ b/plugins/directdownload/src/main/kotlin/org/gameyfin/plugins/download/direct/DirectDownloadPlugin.kt
@@ -51,7 +51,9 @@ class DirectDownloadPlugin(wrapper: PluginWrapper) : ConfigurableGameyfinPlugin(
             return FileDownload(
                 data = streamContentAsSingleFile(path),
                 fileExtension = if (path.isDirectory()) "zip" else path.extension,
-                size = path.fileSize()
+                size = path.isDirectory().let {
+                    if (it) null else path.fileSize()
+                }
             )
         }
 

--- a/plugins/directdownload/src/main/resources/MANIFEST.MF
+++ b/plugins/directdownload/src/main/resources/MANIFEST.MF
@@ -1,4 +1,4 @@
-Plugin-Version: 1.0.1
+Plugin-Version: 1.0.2
 Plugin-Class: org.gameyfin.plugins.download.direct.DirectDownloadPlugin
 Plugin-Id: org.gameyfin.plugins.download.direct
 Plugin-Name: Direct Download


### PR DESCRIPTION
Conditionally add Content-Length header to downloads Only calculate fileSize if file is not a directory in DirectDownloadPlugin